### PR TITLE
Meta tag in header for Google verification

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="google-site-verification" content="lnoeIf-3ggqcee9OedchA1JqtzNHec4a8cVzAHk-SaQ" />
 <title>{{ page.title }}</title>
 <!-- link to main stylesheet -->
 <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">

--- a/google4b330db3827aaee4.html
+++ b/google4b330db3827aaee4.html
@@ -1,1 +1,0 @@
-google-site-verification: google4b330db3827aaee4.html


### PR DESCRIPTION
- Used `meta` tag in header instead of Google verification HTML page