### PR TITLE
Removed code CSS

### DIFF
--- a/css/posts.css
+++ b/css/posts.css
@@ -1,7 +1,3 @@
-code {
-  background-color: "#D3D3D3";
-}
-
 p {
   line-height: 1.5;
 }


### PR DESCRIPTION
- Markdown's Rouge processor automatically takes priority (as the
code.highlighter-route class) over any CSS that applies to code class
only