### PR TITLE
Inherit layout for remaining posts

### DIFF
--- a/_posts/2017-11-20-linkedin-login-wall.md
+++ b/_posts/2017-11-20-linkedin-login-wall.md
@@ -2,7 +2,6 @@
 layout: post
 title: "LinkedIn Login Wall"
 date: 2017-11-20
-custom_styles: "posts"
 ---
 This is a quick fix for people who don't have a LinkedIn account or otherwise
 don't want to log in and let others know when they've viewed a profile.

--- a/_posts/2017-12-18-linkedin-login-skipping-methods.md
+++ b/_posts/2017-12-18-linkedin-login-skipping-methods.md
@@ -2,7 +2,6 @@
 layout: post
 title: "Auto-Bypassing LinkedIn Login"
 date: 2017-12-18
-custom_styles: "posts"
 ---
 
 *This is a follow-up to

--- a/_posts/2017-12-31-xss-csp-bookmarklet.md
+++ b/_posts/2017-12-31-xss-csp-bookmarklet.md
@@ -2,18 +2,17 @@
 layout: post
 title: "XSS, CSP, and a Farewell to Bookmarklets"
 date: 2017-12-31
-custom_styles: "posts"
 ---
 ## XSS, CSP, and a Farewell to Bookmarklets
 
-When [automating the removal of the LinkedIn login wall](https://geordgez.github.io/jots/2017/12/18/linkedin-login-skipping-methods), I tried out a few methods for quickly modifying HTML/CSS. 
+When [automating the removal of the LinkedIn login wall](https://geordgez.github.io/jots/2017/12/18/linkedin-login-skipping-methods), I tried out a few methods for quickly modifying HTML/CSS.
 
-I was eventually inspired by the 
-[NYClean bookmarklet](http://euri.ca/2011/get-around-new-york-times-20-article-limit/index.html) 
+I was eventually inspired by the
+[NYClean bookmarklet](http://euri.ca/2011/get-around-new-york-times-20-article-limit/index.html)
 that removed a similar paywall for The New York Times. Just like LinkedIn, The New York Times would block your browsing if you exceeded their article limit by hitting you with some HTML/CSS elements. Since the full content of the original article was still being delivered with the added visual impediments, however, you could read the article free of obstructions if you just manually edited the HTML/CSS in the browser's element inspector/console. *Note: The New York Times has changed their paywall approach since then, thus rendering NYClean obsolete.*
 
-Here's a headline from 2011 on the NYClean bookmarklet: 
-[That was quick: Four lines of code is all it takes for The New York Times’ paywall to come tumbling down](http://www.niemanlab.org/2011/03/that-was-quick-four-lines-of-code-is-all-it-takes-for-the-new-york-times-paywall-to-come-tumbling-down-2/). 
+Here's a headline from 2011 on the NYClean bookmarklet:
+[That was quick: Four lines of code is all it takes for The New York Times’ paywall to come tumbling down](http://www.niemanlab.org/2011/03/that-was-quick-four-lines-of-code-is-all-it-takes-for-the-new-york-times-paywall-to-come-tumbling-down-2/).
 
 There's actually a wide variety of bookmarklets that serve as lightweight browser add-ons; NYClean demonstrates their potential simplicity and utility. Unlike add-ons, bookmarklets also have the added benefit that they just live in your bookmarks folder/menu/toolbar and don't need to be installed; you can just click them when you need them.
 
@@ -26,10 +25,10 @@ You can test this yourself by creating a simple, innocuous bookmarklet:
 javascript:alert('hello')
 ```
 
-Some sites where you'll get an alert when you click on your bookmarklet: 
-[Google](https://www.google.com/), [Yahoo](https://www.yahoo.com/). 
+Some sites where you'll get an alert when you click on your bookmarklet:
+[Google](https://www.google.com/), [Yahoo](https://www.yahoo.com/).
 
-Some sites where nothing happens: 
+Some sites where nothing happens:
 [Instapaper](https://www.instapaper.com/), [GitHub](https://github.com/).
 
 In fact, for the sites where nothing happens, you can inspect your console to see the message that the bookmarklet script is blocked. GitHub, for instance, displays the following message when the bookmarklet is clicked:
@@ -51,4 +50,4 @@ Brian Donahue of Instapaper [has a great summary on the death of the bookmarklet
 
 [Here's an article](https://www.linkedin.com/pulse/content-security-policy-michal-koczwara) with examples of sites not implementing CSP.
 
-[Lifehacker](https://lifehacker.com/395697/top-10-useful-bookmarklets) and [Hongkiat Lim](https://www.hongkiat.com/blog/100-useful-bookmarklets-for-better-productivity-ultimate-list/) provide some bookmarklets that were popular (and useful) back in the day. 
+[Lifehacker](https://lifehacker.com/395697/top-10-useful-bookmarklets) and [Hongkiat Lim](https://www.hongkiat.com/blog/100-useful-bookmarklets-for-better-productivity-ultimate-list/) provide some bookmarklets that were popular (and useful) back in the day.


### PR DESCRIPTION
- Previously, tested layout inheritance for the first blog post
- Now, applying layout inheritance to all blog posts
- In other words, removing every `custom_styles` from every individual post
  - Since there isn't any custom styling needed for any *single* post
- Also, some EOL (end of line) auto-adjustments from editing in Atom